### PR TITLE
Revert to using row.Scan instead of dbr.Load

### DIFF
--- a/internal/field.go
+++ b/internal/field.go
@@ -104,7 +104,8 @@ func toCamelInitCase(name string, initUpper bool) string {
 			continue
 		}
 		if p == "id" {
-			out += "ID"
+			// Smartpass structs use Id instead of the default ID
+			out += "Id"
 		} else {
 			out += strings.Title(p)
 		}

--- a/internal/gen.go
+++ b/internal/gen.go
@@ -69,14 +69,13 @@ func (t *TmplCtx) codegenQueryMethod(q Query) string {
 	}
 
 	switch q.Cmd {
-	//case ":one":
-	//	if t.EmitPreparedQueries {
-	//		return "q.queryRow"
-	//	}
-	//	return db + ".QueryRowContext"
+	case ":one":
+		if t.EmitPreparedQueries {
+			return "q.queryRow"
+		}
+		return db + ".QueryRowContext"
 
-	// smartpass: treat :many and :one the same so that dbr.Load works
-	case ":many", ":one":
+	case ":many":
 		if t.EmitPreparedQueries {
 			return "q.query"
 		}
@@ -92,10 +91,9 @@ func (t *TmplCtx) codegenQueryMethod(q Query) string {
 
 func (t *TmplCtx) codegenQueryRetval(q Query) (string, error) {
 	switch q.Cmd {
-	//case ":one":
-	//	return "row :=", nil
-	// smartpass: treat :many and :one the same so that dbr.Load works
-	case ":many", ":one":
+	case ":one":
+		return "row :=", nil
+	case ":many":
 		return "rows, err :=", nil
 	case ":exec":
 		return "_, err :=", nil

--- a/internal/imports.go
+++ b/internal/imports.go
@@ -408,8 +408,6 @@ func (i *importer) queryImports(filename string) fileImports {
 
 	// Have to include the database/sql package because part of the DB template is being used in query template
 	std["database/sql"] = struct{}{}
-	// Have to include this so that dbr.Load can be used
-	pkg[ImportSpec{Path: "github.com/gocraft/dbr/v2"}] = struct{}{}
 
 	return sortedImports(std, pkg)
 }

--- a/internal/query.go
+++ b/internal/query.go
@@ -102,6 +102,9 @@ func (v *QueryValue) DefineType() string {
 }
 
 func (v *QueryValue) ReturnName() string {
+	if v.IsPointer() {
+		return "&" + escape(v.Name)
+	}
 	return escape(v.Name)
 }
 

--- a/internal/templates/stdlib/queryCode.tmpl
+++ b/internal/templates/stdlib/queryCode.tmpl
@@ -187,14 +187,11 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
 {{end -}}
 func (q *{{$.InterfaceName}}RepositoryImpl) {{.ShortMethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
     {{- template "queryCodeStdExec" . }}
-	{{- if or (ne .Arg.Pair .Ret.Pair) (ne .Arg.DefineType .Ret.DefineType) }}
-	var {{.Ret.Name}} {{.Ret.DefineType}}
-	{{- end}}
-    if err != nil {
-        return {{.Ret.ReturnName}}, err
-    }
-	_, err = dbr.Load(rows, &{{.Ret.Name}})
-	return {{.Ret.ReturnName}}, err
+    {{- if or (ne .Arg.Pair .Ret.Pair) (ne .Arg.DefineType .Ret.DefineType) }}
+    var {{.Ret.Name}} {{.Ret.DefineType}}
+    {{- end}}
+    err := row.Scan({{.Ret.Scan}})
+    return {{.Ret.ReturnName}}, err
 }
 {{end}}
 
@@ -211,8 +208,20 @@ func (q *{{$.InterfaceName}}RepositoryImpl) {{.ShortMethodName}}(ctx context.Con
     {{else}}
     var items []{{.Ret.DefineType}}
     {{end -}}
-    _, err = dbr.Load(rows, &items)
-    return items, err
+    for rows.Next() {
+        var {{.Ret.Name}} {{.Ret.Type}}
+        if err := rows.Scan({{.Ret.Scan}}); err != nil {
+            return nil, err
+        }
+        items = append(items, {{.Ret.ReturnName}})
+    }
+    if err := rows.Close(); err != nil {
+        return nil, err
+    }
+    if err := rows.Err(); err != nil {
+        return nil, err
+    }
+    return items, nil
 }
 {{end}}
 

--- a/internal/templates/stdlib/queryCode.tmpl
+++ b/internal/templates/stdlib/queryCode.tmpl
@@ -188,9 +188,14 @@ type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
 func (q *{{$.InterfaceName}}RepositoryImpl) {{.ShortMethodName}}(ctx context.Context, {{ dbarg }} {{.Arg.Pair}}) ({{.Ret.DefineType}}, error) {
     {{- template "queryCodeStdExec" . }}
     {{- if or (ne .Arg.Pair .Ret.Pair) (ne .Arg.DefineType .Ret.DefineType) }}
-    var {{.Ret.Name}} {{.Ret.DefineType}}
+    var {{.Ret.Name}} {{.Ret.Type}}
     {{- end}}
     err := row.Scan({{.Ret.Scan}})
+    {{- if .Ret.IsPointer }}
+    if err == sql.ErrNoRows {
+		return nil, nil
+	}
+    {{- end}}
     return {{.Ret.ReturnName}}, err
 }
 {{end}}


### PR DESCRIPTION
`dbr.Load` uses reflection to populate the results structs, which can run into issues when embedding multiple nested structs with overlapping field/column names. (It will overwrite the field in the first struct with the data that should be in the second struct, leaving the second struct zero'd out.) The original sqlc behavior used `row.Scan`, which instead looks at the returned columns in order. This would be tedious to enumerate by hand, but it doesn't matter when it's generated for us.

This seems orthogonal to the issue of using pointers vs `sql.NullString` etc for nullable types, and so I was able to largely undo our previous changes. The one change I did have to make was to preserve the behavior on `:one` queries when no record is found; we want to return nil instead of an error.

I tested this with my local server checkout:
1. Existing tests pass, which does cover some of the Schedules-related queries.
2. I was able to query Locations and Pinnables, embedded in the same query, and pass that data through to the frontend to confirm it was populating the name-overlapping fields correctly.

I'll also put up a draft PR of the server code changes for easier review of the changes generated. Edit: https://github.com/smartpass/smartpass-server/pull/151